### PR TITLE
Refactor table ids

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ group :test do
   gem 'database_cleaner'
   gem 'simplecov', :require => false
   gem 'launchy'   
-  gem 'selenium-webdriver'
+  gem 'poltergeist'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,9 +50,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    childprocess (0.5.2)
-      ffi (~> 1.0, >= 1.0.11)
     choice (0.1.6)
+    cliver (0.3.2)
     coderay (1.1.0)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
@@ -71,7 +70,6 @@ GEM
     factory_girl_rails (4.4.1)
       factory_girl (~> 4.4.0)
       railties (>= 3.0.0)
-    ffi (1.9.3)
     hike (1.2.3)
     i18n (0.6.9)
     jbuilder (2.0.6)
@@ -99,6 +97,11 @@ GEM
       mini_portile (~> 0.5.0)
     normalize-rails (3.0.1)
     pg (0.17.1)
+    poltergeist (1.5.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
     polyglot (0.3.4)
     pry (0.9.12.6)
       coderay (~> 1.0)
@@ -144,7 +147,6 @@ GEM
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
     ruby-graphviz (1.0.9)
-    rubyzip (1.1.3)
     sass (3.2.19)
     sass-rails (4.0.3)
       railties (>= 4.0.0, < 5.0)
@@ -154,11 +156,6 @@ GEM
     sdoc (0.4.0)
       json (~> 1.8)
       rdoc (~> 4.0, < 5.0)
-    selenium-webdriver (2.41.0)
-      childprocess (>= 0.5.0)
-      multi_json (~> 1.0)
-      rubyzip (~> 1.0)
-      websocket (~> 1.0.4)
     simplecov (0.8.2)
       docile (~> 1.1.0)
       multi_json
@@ -193,7 +190,7 @@ GEM
     uglifier (2.5.0)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
-    websocket (1.0.7)
+    websocket-driver (0.3.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -217,6 +214,7 @@ DEPENDENCIES
   net-ssh (~> 2.7.0)
   normalize-rails
   pg
+  poltergeist
   pry
   rack-test
   railroady
@@ -225,7 +223,6 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 4.0.2)
   sdoc (~> 0.4.0)
-  selenium-webdriver
   simplecov
   spring
   uglifier (>= 1.3.0)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,10 +21,6 @@ class UsersController < ApplicationController
     end
   end
 
-  def show
-    @user = User.find(params[:id])
-  end
-
   private
   def new_user_params
     params.require(:user).permit(:user_name,:email,:password,:password_confirmation,:guest) 

--- a/app/models/level.rb
+++ b/app/models/level.rb
@@ -5,14 +5,20 @@ class Level < ActiveRecord::Base
   has_many :level_schemas, :dependent => :destroy
   has_many :user_levels, :dependent => :destroy
 
-  before_create :load_dump
+  before_save :load_dump
 
   def load_dump
-    self.dump = File.open(self.database_path) do |file|
-      file.read
-    end
-    if !self.dump
-      self.errors.add(:dump, "Could not load dump file")
+    if self.database_path
+        begin
+          self.dump = File.open(self.database_path) do |file|
+            file.read
+          end
+        rescue StandardError 
+          self.dump = nil
+        end
+      if !self.dump
+        self.errors.add(:dump, "Could not load dump file")
+      end
     end
   end
 

--- a/db/dumps/lvl1.sql
+++ b/db/dumps/lvl1.sql
@@ -1,9 +1,9 @@
-CREATE TABLE cities (name VARCHAR(255), population INTEGER);
+CREATE TABLE cities (city_name VARCHAR(255), population INTEGER);
 
-INSERT INTO cities (name,population) VALUES ('New York', 8337000);
-INSERT INTO cities (name,population) VALUES ('Paris', 2211000);
-INSERT INTO cities (name,population) VALUES ('San Francisco', 825000);
-INSERT INTO cities (name,population) VALUES ('London', 8308000);
-INSERT INTO cities (name,population) VALUES ('Moscow', 11500000);
-INSERT INTO cities (name,population) VALUES ('Tokyo', 13230000);
-INSERT INTO cities (name,population) VALUES ('Shanghai', 24000000);
+INSERT INTO cities (city_name, population) VALUES ('New York', 8337000);
+INSERT INTO cities (city_name, population) VALUES ('Paris', 2211000);
+INSERT INTO cities (city_name, population) VALUES ('San Francisco', 825000);
+INSERT INTO cities (city_name, population) VALUES ('London', 8308000);
+INSERT INTO cities (city_name, population) VALUES ('Moscow', 11500000);
+INSERT INTO cities (city_name, population) VALUES ('Tokyo', 13230000);
+INSERT INTO cities (city_name, population) VALUES ('Shanghai', 24000000);

--- a/db/dumps/lvl10.sql
+++ b/db/dumps/lvl10.sql
@@ -1,14 +1,14 @@
-CREATE TABLE cities (id serial PRIMARY KEY,name VARCHAR(255), population INTEGER);
+CREATE TABLE cities (city_id serial PRIMARY KEY, city_name VARCHAR(255), population INTEGER);
 
-INSERT INTO cities (name,population) VALUES ('New York', 8337000);
-INSERT INTO cities (name,population) VALUES ('Paris', 2211000);
-INSERT INTO cities (name,population) VALUES ('San Francisco', 825000);
-INSERT INTO cities (name,population) VALUES ('London', 8308000);
-INSERT INTO cities (name,population) VALUES ('Moscow', 11500000);
-INSERT INTO cities (name,population) VALUES ('Tokyo', 13230000);
-INSERT INTO cities (name,population) VALUES ('Shanghai', 24000000);
+INSERT INTO cities (city_name,population) VALUES ('New York', 8337000);
+INSERT INTO cities (city_name,population) VALUES ('Paris', 2211000);
+INSERT INTO cities (city_name,population) VALUES ('San Francisco', 825000);
+INSERT INTO cities (city_name,population) VALUES ('London', 8308000);
+INSERT INTO cities (city_name,population) VALUES ('Moscow', 11500000);
+INSERT INTO cities (city_name,population) VALUES ('Tokyo', 13230000);
+INSERT INTO cities (city_name,population) VALUES ('Shanghai', 24000000);
 
-CREATE TABLE missiles (id serial PRIMARY KEY, model_name VARCHAR(255), nationality VARCHAR(255), target_city_id INTEGER);
+CREATE TABLE missiles (missile_id serial PRIMARY KEY, model_name VARCHAR(255), nationality VARCHAR(255), target_city_id INTEGER);
 
 INSERT INTO missiles (model_name, nationality, target_city_id) VALUES ('Peacekeeper','USA', 7);
 INSERT INTO missiles (model_name, nationality, target_city_id) VALUES ('Minuteman','USA', 5);

--- a/db/dumps/lvl2.sql
+++ b/db/dumps/lvl2.sql
@@ -1,9 +1,9 @@
-CREATE TABLE cities (name VARCHAR(255), population INTEGER);
+CREATE TABLE cities (city_name VARCHAR(255), population INTEGER);
 
-INSERT INTO cities (name,population) VALUES ('New York', 8337000);
-INSERT INTO cities (name,population) VALUES ('Paris', 2211000);
-INSERT INTO cities (name,population) VALUES ('San Francisco', 825000);
-INSERT INTO cities (name,population) VALUES ('London', 8308000);
-INSERT INTO cities (name,population) VALUES ('Moscow', 11500000);
-INSERT INTO cities (name,population) VALUES ('Tokyo', 13230000);
-INSERT INTO cities (name,population) VALUES ('Shanghai', 24000000);
+INSERT INTO cities (city_name, population) VALUES ('New York', 8337000);
+INSERT INTO cities (city_name, population) VALUES ('Paris', 2211000);
+INSERT INTO cities (city_name, population) VALUES ('San Francisco', 825000);
+INSERT INTO cities (city_name, population) VALUES ('London', 8308000);
+INSERT INTO cities (city_name, population) VALUES ('Moscow', 11500000);
+INSERT INTO cities (city_name, population) VALUES ('Tokyo', 13230000);
+INSERT INTO cities (city_name, population) VALUES ('Shanghai', 24000000);

--- a/db/dumps/lvl3.sql
+++ b/db/dumps/lvl3.sql
@@ -1,9 +1,9 @@
-CREATE TABLE cities (name VARCHAR(255), population INTEGER);
+CREATE TABLE cities (city_name VARCHAR(255), population INTEGER);
 
-INSERT INTO cities (name,population) VALUES ('New York', 8337000);
-INSERT INTO cities (name,population) VALUES ('Paris', 2211000);
-INSERT INTO cities (name,population) VALUES ('San Francisco', 825000);
-INSERT INTO cities (name,population) VALUES ('London', 8308000);
-INSERT INTO cities (name,population) VALUES ('Moscow', 11500000);
-INSERT INTO cities (name,population) VALUES ('Tokyo', 13230000);
-INSERT INTO cities (name,population) VALUES ('Shanghai', 24000000);
+INSERT INTO cities (city_name, population) VALUES ('New York', 8337000);
+INSERT INTO cities (city_name, population) VALUES ('Paris', 2211000);
+INSERT INTO cities (city_name, population) VALUES ('San Francisco', 825000);
+INSERT INTO cities (city_name, population) VALUES ('London', 8308000);
+INSERT INTO cities (city_name, population) VALUES ('Moscow', 11500000);
+INSERT INTO cities (city_name, population) VALUES ('Tokyo', 13230000);
+INSERT INTO cities (city_name, population) VALUES ('Shanghai', 24000000);

--- a/db/dumps/lvl6.sql
+++ b/db/dumps/lvl6.sql
@@ -1,4 +1,4 @@
-CREATE TABLE missiles (id serial PRIMARY KEY, model_name VARCHAR(255), nationality VARCHAR(255));
+CREATE TABLE missiles (missile_id serial PRIMARY KEY, model_name VARCHAR(255), nationality VARCHAR(255));
 
 INSERT INTO missiles (model_name, nationality) VALUES ('Peacekeeper','USA');
 INSERT INTO missiles (model_name, nationality) VALUES ('Minuteman','USA');

--- a/db/dumps/lvl8.sql
+++ b/db/dumps/lvl8.sql
@@ -1,4 +1,4 @@
-CREATE TABLE missiles (id serial PRIMARY KEY, model_name VARCHAR(255), nationality VARCHAR(255), target_city_id INTEGER);
+CREATE TABLE missiles (missile_id serial PRIMARY KEY, model_name VARCHAR(255), nationality VARCHAR(255), target_city_id INTEGER);
 
 INSERT INTO missiles (model_name, nationality, target_city_id) VALUES ('Peacekeeper','USA', 7);
 INSERT INTO missiles (model_name, nationality, target_city_id) VALUES ('Minuteman','USA', 5);

--- a/db/dumps/lvl9.sql
+++ b/db/dumps/lvl9.sql
@@ -1,14 +1,14 @@
-CREATE TABLE cities (id serial PRIMARY KEY,name VARCHAR(255), population INTEGER);
+CREATE TABLE cities (city_id serial PRIMARY KEY, city_name VARCHAR(255), population INTEGER);
 
-INSERT INTO cities (name,population) VALUES ('New York', 8337000);
-INSERT INTO cities (name,population) VALUES ('Paris', 2211000);
-INSERT INTO cities (name,population) VALUES ('San Francisco', 825000);
-INSERT INTO cities (name,population) VALUES ('London', 8308000);
-INSERT INTO cities (name,population) VALUES ('Moscow', 11500000);
-INSERT INTO cities (name,population) VALUES ('Tokyo', 13230000);
-INSERT INTO cities (name,population) VALUES ('Shanghai', 24000000);
+INSERT INTO cities (city_name,population) VALUES ('New York', 8337000);
+INSERT INTO cities (city_name,population) VALUES ('Paris', 2211000);
+INSERT INTO cities (city_name,population) VALUES ('San Francisco', 825000);
+INSERT INTO cities (city_name,population) VALUES ('London', 8308000);
+INSERT INTO cities (city_name,population) VALUES ('Moscow', 11500000);
+INSERT INTO cities (city_name,population) VALUES ('Tokyo', 13230000);
+INSERT INTO cities (city_name,population) VALUES ('Shanghai', 24000000);
 
-CREATE TABLE missiles (id serial PRIMARY KEY, model_name VARCHAR(255), nationality VARCHAR(255), target_city_id INTEGER);
+CREATE TABLE missiles (missile_id serial PRIMARY KEY, model_name VARCHAR(255), nationality VARCHAR(255), target_city_id INTEGER);
 
 INSERT INTO missiles (model_name, nationality, target_city_id) VALUES ('Peacekeeper','USA', 7);
 INSERT INTO missiles (model_name, nationality, target_city_id) VALUES ('Minuteman','USA', 5);

--- a/db/levels/lvl1.yml
+++ b/db/levels/lvl1.yml
@@ -1,9 +1,9 @@
-correct_query: "SELECT name from cities;"
+correct_query: "SELECT city_name from cities;"
 level: 
-  answer: "[{\"name\"=>\"New York\"}, {\"name\"=>\"Paris\"}, {\"name\"=>\"San Francisco\"}, {\"name\"=>\"London\"}, {\"name\"=>\"Moscow\"}, {\"name\"=>\"Tokyo\"}, {\"name\"=>\"Shanghai\"}]"
+  answer: "[{\"city_name\"=>\"New York\"}, {\"city_name\"=>\"Paris\"}, {\"city_name\"=>\"San Francisco\"}, {\"city_name\"=>\"London\"}, {\"city_name\"=>\"Moscow\"}, {\"city_name\"=>\"Tokyo\"}, {\"city_name\"=>\"Shanghai\"}]"
   database_path: db/dumps/lvl1.sql
   level_type: read
-  prompt: "Select the <code>name</code> column from the <code>cities</code> table."
+  prompt: "Select the <code>city_name</code> column from the <code>cities</code> table."
   stage_number: 1
   title: "Would you like to play a game?"
 level_pages: 
@@ -12,12 +12,12 @@ level_pages:
   - page_number: 2
     content: "<p>A <em>table</em> is a lot like a spreadsheet. Each <em>row</em> of a table represents a <em>record</em>, which could be an individual item of any kind. Each <em>column</em> in a <em>row</em> represents one property of that record, like its unique identifier, its name, or its strength in megatons.</p><p>Each <em>table</em> generally stores the data for one kind of resource, with its name indicating the kind of resource it stores.</p><p>Tables can be related to each other by holding information about each other's <em>rows</em> (that's where the 'relational' part comes in), but more on that later. For now, there's a pressing need. You must use <code>SQL</code> to save the world from nuclear destruction!</p>"
   - page_number: 3
-    content: "<p>So let's get started. We have a small database with a single table: <code>cities</code></p><p>Your first task is get the full list of city names from the database to send to our Civil Defense Corps.</p><p>You'll do that by using a SQL <code>SELECT</code> query. A <code>SELECT</code> statement retrieves data from tables by specifying which columns and rows to pull out. Here's what a basic select query looks like:</p><p><code>SELECT <em>column_name</em> FROM <em>table_name</em>;</code></p><p>Here's an example of how it would be used:</p><p><code>SELECT age FROM cats;</code></p><p>That would <code>SELECT</code> the <code>age</code> column from the <code>cats</code> table, and returns a result table with a list of cat ages. Why don't you give it a try by selecting the <code>name</code> column from the <code>cities</code> table?</p>"
+    content: "<p>So let's get started. We have a small database with a single table: <code>cities</code></p><p>Your first task is get the full list of city names from the database to send to our Civil Defense Corps.</p><p>You'll do that by using a SQL <code>SELECT</code> query. A <code>SELECT</code> statement retrieves data from tables by specifying which columns and rows to pull out. Here's what a basic select query looks like:</p><p><code>SELECT <em>column_name</em> FROM <em>table_name</em>;</code></p><p>Here's an example of how it would be used:</p><p><code>SELECT age FROM cats;</code></p><p>That would <code>SELECT</code> the <code>age</code> column from the <code>cats</code> table, and returns a result table with a list of cat ages. Why don't you give it a try by selecting the <code>city_name</code> column from the <code>cities</code> table?</p>"
 level_schemas: 
   - 
     schema_columns: 
       - 
-        column_name: name
+        column_name: city_name
         column_type: varchar(255)
       - 
         column_name: population
@@ -25,11 +25,11 @@ level_schemas:
     table_name: cities
 level_tests:
   - test_query: "has_col?"
-    expected_output: "name"
-    error_message: "Your results should have the name column."
+    expected_output: "city_name"
+    error_message: "Your results should have the city_name column"
   - test_query: "has_col_count?"
     expected_output: "1"
-    error_message: "Your results should only have exactly 1 column."
+    error_message: "Your results should include exactly 1 column"
   - test_query: "has_row_count?"
     expected_output: 7
-    error_message: "Your result should return all 7 rows from the cities table."
+    error_message: "Your result should return all 7 rows from the cities table"

--- a/db/levels/lvl10.yml
+++ b/db/levels/lvl10.yml
@@ -1,25 +1,25 @@
-correct_query: "SELECT cities.name, missiles.model_name, missiles.nationality FROM cities JOIN missiles on missiles.target_city_id = cities.id;"
+correct_query: "SELECT cities.city_name, missiles.model_name, missiles.nationality FROM cities JOIN missiles on missiles.target_city_id = cities.city_id;"
 level: 
   stage_number: 10
   title: "Target Acquisition"
   prompt: "Select a list of city names, the missile models targeting them, and the nationility of those missiles by using a <code>JOIN</code>."
   database_path: "db/dumps/lvl10.sql"
-  answer: "[{\"name\"=>\"New York\", \"model_name\"=>\"Topol\", \"nationality\"=>\"Russia\"}, {\"name\"=>\"San Francisco\", \"model_name\"=>\"Dongfeng-5\", \"nationality\"=>\"China\"}, {\"name\"=>\"London\", \"model_name\"=>\"Yars\", \"nationality\"=>\"Russia\"}, {\"name\"=>\"Moscow\", \"model_name\"=>\"Jericho III\", \"nationality\"=>\"Israel\"}, {\"name\"=>\"Moscow\", \"model_name\"=>\"Minuteman\", \"nationality\"=>\"USA\"}, {\"name\"=>\"Tokyo\", \"model_name\"=>\"Dongfeng-31\", \"nationality\"=>\"China\"}, {\"name\"=>\"Shanghai\", \"model_name\"=>\"Agni-V\", \"nationality\"=>\"India\"}, {\"name\"=>\"Shanghai\", \"model_name\"=>\"Peacekeeper\", \"nationality\"=>\"USA\"}]"
+  answer: "[{\"city_name\"=>\"New York\", \"model_name\"=>\"Topol\", \"nationality\"=>\"Russia\"}, {\"city_name\"=>\"San Francisco\", \"model_name\"=>\"Dongfeng-5\", \"nationality\"=>\"China\"}, {\"city_name\"=>\"London\", \"model_name\"=>\"Yars\", \"nationality\"=>\"Russia\"}, {\"city_name\"=>\"Moscow\", \"model_name\"=>\"Jericho III\", \"nationality\"=>\"Israel\"}, {\"city_name\"=>\"Moscow\", \"model_name\"=>\"Minuteman\", \"nationality\"=>\"USA\"}, {\"city_name\"=>\"Tokyo\", \"model_name\"=>\"Dongfeng-31\", \"nationality\"=>\"China\"}, {\"city_name\"=>\"Shanghai\", \"model_name\"=>\"Agni-V\", \"nationality\"=>\"India\"}, {\"city_name\"=>\"Shanghai\", \"model_name\"=>\"Peacekeeper\", \"nationality\"=>\"USA\"}]"
   level_type: "read"
 level_pages:
   - page_number: 1
-    content: "<p>Civil Defense is scrambling jets to intercept the missiles you found in the last stage. They need you to generate a list of the cities being targeted, paired with the model and nation of the missile targeting them. They don't have time to look through all the data in both tables, so you'll need to get just the <code>name</code> column from the <code>cities</code> table, and the <code>model_name</code> and <code>nationality</code> from each matching missile row.</p><p>To do this, you'll use an inner JOIN, just as in the last stage, but this time using the syntax to select specific columns.</p>"
+    content: "<p>Civil Defense is scrambling jets to intercept the missiles you found in the last stage. They need you to generate a list of the cities being targeted, paired with the model and nation of the missile targeting them. They don't have time to look through all the data in both tables, so you'll need to get just the <code>city_name</code> column from the <code>cities</code> table, and the <code>model_name</code> and <code>nationality</code> columns from each matching missile row.</p><p>To do this, you'll use an inner JOIN, just as in the last stage, but this time using the syntax to select specific columns.</p>"
   - page_number: 2
-    content: "<p>To select only specific columns, you'll use the 'dot' notation in the <code>SELECT</code> portion of your JOIN query. Dot notation takes the following format <code><em>table_name.column_name</em></code>. In a JOIN where you want to get the name of a cat and the name of its owner from related tables, you'd write something like this:</p><p><pre><code>SELECT cats.name, owners.name\nFROM cats\nJOIN owners\nON cats.owner_id = owner.id;</code></pre></p><p>Take a look at the schema for the missiles and cities tables on the right, and see if you can select the <code>names</code> of cities and the <code>model_name</code> and <code>nationality</code> of the missile targeting each one."
+    content: "<p>To select only specific columns, you'll use the 'dot' notation in the <code>SELECT</code> portion of your JOIN query. Dot notation takes the following format <code><em>table_name.column_name</em></code>. In a JOIN where you want to get the name of a cat and the name of its owner from related tables, you'd write something like this:</p><p><pre><code>SELECT cats.name, owners.name\nFROM cats\nJOIN owners\nON cats.owner_id = owner.id;</code></pre></p><p>Take a look at the schema for the missiles and cities tables on the right, and see if you can select the <code>city_name</code> of each targeted city and the <code>model_name</code> and <code>nationality</code> of the missile targeting each one."
 level_schemas: 
   - 
     table_name: cities
     schema_columns: 
       - 
-        column_name: id
+        column_name: city_id
         column_type: serial
       - 
-        column_name: name
+        column_name: city_name
         column_type: varchar(255)
       - 
         column_name: population
@@ -28,7 +28,7 @@ level_schemas:
     table_name: missiles
     schema_columns: 
       - 
-        column_name: id
+        column_name: missile_id
         column_type: serial
       - 
         column_name: model_name
@@ -41,8 +41,8 @@ level_schemas:
         column_type: integer
 level_tests:
   - test_query: "has_col?"
-    expected_output: "name"
-    error_message: "Your results should include data from cities.name"
+    expected_output: "city_name"
+    error_message: "Your results should include data from cities.city_name"
   - test_query: "has_col?"
     expected_output: "model_name"
     error_message: "Your results should include data from missiles.model_name" 

--- a/db/levels/lvl2.yml
+++ b/db/levels/lvl2.yml
@@ -4,18 +4,18 @@ level:
   title: "Select all the things!"
   prompt: "Select every <em>row</em> and <em>column</em> from <code>cities</code> by using <code>*</code>."
   database_path: "db/dumps/lvl1.sql"
-  answer: "[{\"name\"=>\"New York\", \"population\"=>\"8337000\"}, {\"name\"=>\"Paris\", \"population\"=>\"2211000\"}, {\"name\"=>\"San Francisco\", \"population\"=>\"825000\"}, {\"name\"=>\"London\", \"population\"=>\"8308000\"}, {\"name\"=>\"Moscow\", \"population\"=>\"11500000\"}, {\"name\"=>\"Tokyo\", \"population\"=>\"13230000\"}, {\"name\"=>\"Shanghai\", \"population\"=>\"24000000\"}]"
+  answer: "[{\"city_name\"=>\"New York\", \"population\"=>\"8337000\"}, {\"city_name\"=>\"Paris\", \"population\"=>\"2211000\"}, {\"city_name\"=>\"San Francisco\", \"population\"=>\"825000\"}, {\"city_name\"=>\"London\", \"population\"=>\"8308000\"}, {\"city_name\"=>\"Moscow\", \"population\"=>\"11500000\"}, {\"city_name\"=>\"Tokyo\", \"population\"=>\"13230000\"}, {\"city_name\"=>\"Shanghai\", \"population\"=>\"24000000\"}]"
   level_type: "read"
-default_text: "\n\nname            |\n‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾\nNew York        |\nParis           |\nSan Francisco   |\nLondon          |\nMoscow          |\nTokyo           |\nShanghai        |\n"
+default_text: "\n\ncity_name       |\n‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾\nNew York        |\nParis           |\nSan Francisco   |\nLondon          |\nMoscow          |\nTokyo           |\nShanghai        |\n"
 level_pages:
   - 
     page_number: 1
-    content: "<p>So we figured out how to get a list of city names. Cool beans. But what if we want more information? Enter the <code>*</code> character.</p><p><code>*</code> is a wildcard character, it matches every column in the table. Telling a table to <code>SELECT *</code> is telling it to get all the things!</p><p> It will return every column and every row! Give it a try!</p><p>Try using a select query with <code>*</code> instead of <code>name</code>. This should return the entire <code>cities</code> table as the result.</p>"
+    content: "<p>So we figured out how to get a list of city names. Cool beans. But what if we want more information? Enter the <code>*</code> character.</p><p><code>*</code> is a wildcard character, it matches every column in the table. Telling a table to <code>SELECT *</code> is telling it to get all the things!</p><p> It will return every column and every row! Give it a try!</p><p>Try using a select query with <code>*</code> instead of <code>city_name</code>. This should return the entire <code>cities</code> table as the result.</p>"
 level_schemas: 
   - 
     schema_columns: 
       - 
-        column_name: name
+        column_name: city_name
         column_type: varchar(255)
       - 
         column_name: population
@@ -23,14 +23,14 @@ level_schemas:
     table_name: cities
 level_tests:
   - test_query: "has_col?"
-    expected_output: "name"
-    error_message: "Your results should have the name column."
+    expected_output: "city_name"
+    error_message: "Your results should include the city_name column"
   - test_query: "has_col?"
     expected_output: "population"
-    error_message: "Your results should have the population column."    
+    error_message: "Your results should include the population column"    
   - test_query: "has_col_count?"
     expected_output: "2"
-    error_message: "Your results should have exactly 2 columns."
+    error_message: "Your results should include exactly 2 columns"
   - test_query: "has_row_count?"
     expected_output: 7
-    error_message: "Your result should return all 7 rows from the cities table."
+    error_message: "Your result should include all 7 rows from the cities table."

--- a/db/levels/lvl3.yml
+++ b/db/levels/lvl3.yml
@@ -1,24 +1,24 @@
-correct_query: "SELECT * FROM cities WHERE name='New York' OR population > 10000000;"
+correct_query: "SELECT * FROM cities WHERE city_name='New York' OR population > 10000000;"
 level: 
   stage_number: 3
   title: "Where were we?"
-  prompt: "Select all data from all rows where the city is named New York, or the population is greater than ten million. Use <code>WHERE</code> and <code>OR</code>."
+  prompt: "Select all data from all rows where the city_name is New York, or the population of the city is greater than 10000000 using <code>WHERE</code> and <code>OR</code>."
   database_path: "db/dumps/lvl3.sql"
-  answer: "[{\"name\"=>\"New York\", \"population\"=>\"8337000\"}, {\"name\"=>\"Moscow\", \"population\"=>\"11500000\"}, {\"name\"=>\"Tokyo\", \"population\"=>\"13230000\"}, {\"name\"=>\"Shanghai\", \"population\"=>\"24000000\"}]"
+  answer: "[{\"city_name\"=>\"New York\", \"population\"=>\"8337000\"}, {\"city_name\"=>\"Moscow\", \"population\"=>\"11500000\"}, {\"city_name\"=>\"Tokyo\", \"population\"=>\"13230000\"}, {\"city_name\"=>\"Shanghai\", \"population\"=>\"24000000\"}]"
   level_type: "read"
 level_pages:
   - page_number: 1
     content: "<p>So now we know how to return a single column, and we know how to return all the columns. But so far our queries have been returning data for every single row in the table.</p><p>This time, let's try getting more specific and returning only the particular rows where certain conditions are met. For instance, what if I just want to get populations, but only for New York or Paris?</p><p>One way to do that is with a <code>WHERE</code> clause. A <code>WHERE</code> clause filters the results based on certain criteria."
   - page_number: 2
-    content: "<p>So how do we use it? The general syntax is:</p><p><code>SELECT <em>columns</em> FROM <em>table</em> WHERE <em>condition</em>;</code></p><p>While it seems pretty basic, you can make the condition as complex as you need it to be. For example, you can combine conditions using boolean operators such as <code>AND</code> , <code>NOT</code> , and <code>OR</code>. For number columns you can also filter by using the <code><</code>,<code>></code>,<code>=</code>,<code><=</code>,<code>>=</code> operators.<p><p>Here is an example:</p><p><code>SELECT * FROM cities WHERE population >8000000;</code></p>"
+    content: "<p>So how do we use it? The general syntax is:</p><p><code>SELECT <em>columns</em> FROM <em>table</em> WHERE <em>condition</em>;</code></p><p>While it seems pretty basic, you can make the condition as complex as you need it to be. For example, you can combine conditions using boolean operators such as <code>AND</code> , <code>NOT</code> , and <code>OR</code>. For number columns you can also filter by using the <code><</code>, <code>></code>, <code>=</code>, <code><=</code>, <code>>=</code> operators.<p><p>Here is an example:</p><p><code>SELECT * FROM cities WHERE population > 8000000;</code></p>"
   - page_number: 3
-    content: "<p>The Following are all valid queries:</p><p><code>SELECT name FROM cities WHERE name='New York' OR name='Paris';</code></p><p><code>SELECT * FROM cities WHERE NOT name='New York'</code></p><p>Now you give it a try. Go ahead and get the list of cities whose name is New York or whose population is over 10,000,000. We'll want all the columns.</p><p>Feel free to break up your query into multiple lines to make it easier.<p><p>Tip: <code>SQL</code> strings (like the <code>VARCHAR</code> datatype) are specified with 'single quotes' rather than \"double quotes\". We'll dive deeper into varchar and other datatypes in the next level. </p>"
-default_text: "name            | population      |\n‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾\nNew York        | 8337000         |\nParis           | 2211000         |\nSan Francisco   | 825000          |\nLondon          | 8308000         |\nMoscow          | 11500000        |\nTokyo           | 13230000        |\nShanghai        | 24000000        |\n"
+    content: "<p>The Following are all valid queries:</p><p><code>SELECT city_name FROM cities WHERE city_name='New York' OR city_name='Paris';</code></p><p><code>SELECT * FROM cities WHERE NOT city_name='New York'</code></p><p>Now you give it a try. Go ahead and get the list of cities whose city_name is New York or whose population is over 10,000,000. We'll want all the columns.</p><p>Feel free to break up your query into multiple lines to make it easier.<p><p><em>Tip: <code>SQL</code> strings (a string is a sequence of text, like the data stored in the city_name column) are entered in queries surrounded with 'single quotes' (rather than \"double quotes\") to seperate them from SQL commands and names. Integers, like the numbers stored in the poulation column, don't need to be surrounded with quotes at all. We'll dive deeper into datatypes in the next level.</em></p>"
+default_text: "city_name       | population      |\n‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾\nNew York        | 8337000         |\nParis           | 2211000         |\nSan Francisco   | 825000          |\nLondon          | 8308000         |\nMoscow          | 11500000        |\nTokyo           | 13230000        |\nShanghai        | 24000000        |\n"
 level_schemas: 
   - 
     schema_columns: 
       - 
-        column_name: name
+        column_name: city_name
         column_type: varchar(255)
       - 
         column_name: population
@@ -26,7 +26,7 @@ level_schemas:
     table_name: cities
 level_tests:
   - test_query: "has_col?"
-    expected_output: "name"
+    expected_output: "city_name"
     error_message: "Your result should have the name column."
   - test_query: "has_col?"
     expected_output: "population"
@@ -38,5 +38,5 @@ level_tests:
     expected_output: 4
     error_message: "Your result should return exactly 4 rows from the cities table."
   - test_query: "has_row?"
-    expected_output: "{\"name\"=>\"New York\", \"population\"=>\"8337000\"}"
+    expected_output: "{\"city_name\"=>\"New York\", \"population\"=>\"8337000\"}"
     error_message: "Your result should include 'New York'."

--- a/db/levels/lvl4.yml
+++ b/db/levels/lvl4.yml
@@ -1,4 +1,4 @@
-correct_query: "CREATE TABLE cities (name VARCHAR(255), population INTEGER);"
+correct_query: "CREATE TABLE cities (city_name VARCHAR(255), population INTEGER);"
 level: 
   stage_number: 4
   title: "Scheming to create"
@@ -14,24 +14,24 @@ level_pages:
   - page_number: 3
     content: "<p>The datatype literally indicates what type of data a column can store, and how much of it. Different SQL databases have different data types available to them, but some generally available datatypes are things like text, numbers, dates, and true/false boolean values.</p>"
   - page_number: 4
-    content: "<p>The first column of the cities table is 'name', and its datatype is <code>varchar(255)</code>. This is just SQL's way of indicating that a column can store text (<em>variable characters</em>), but that the storage is limited to 255 characters. So a <code>varchar(140)</code> column would be able to store exactly a single tweet, but no more.</p><p>The second column, <code>population</code>, is an <code>integer</code> datatype, which stores a number without a decimal value attached.</p><p>So let's put this all together and create our <code>cities</code> table!The basic syntax for a <code>CREATE</code> statement is:</p><p><pre><code>CREATE TABLE <em>tablename</em> (\n  <em>column1 TYPE1,\n  column2 TYPE2</em>\n);</code></pre></p>"
+    content: "<p>The first column of the cities table is 'city_name', and its datatype is <code>varchar(255)</code>. This is just SQL's way of indicating that a column can store text (<em>variable characters</em>), but that the storage is limited to 255 characters. So a <code>varchar(140)</code> column would be able to store exactly a single tweet, but no more.</p><p>The second column, <code>population</code>, is an <code>integer</code> datatype, which stores a number without a decimal value attached.</p><p>So let's put this all together and create our <code>cities</code> table!The basic syntax for a <code>CREATE</code> statement is:</p><p><pre><code>CREATE TABLE <em>tablename</em> (\n  <em>column1 TYPE1,\n  column2 TYPE2</em>\n);</code></pre></p>"
   - page_number: 5
     content: "<p>Here are some examples:</p><p><pre><code>CREATE TABLE people (\n  name VARCHAR(64),\n  age INTEGER\n);</code></pre></p><p><pre><code>CREATE TABLE bank_accounts (\n  account_number INTEGER,\n  balance INTEGER\n);</code></pre></p><p>Now go ahead and try to create the cities table.</p><p>Use the schema to the right if you get stuck.</p>"
 level_tests:
-  - test_query: "select column_name from INFORMATION_SCHEMA.COLUMNS where table_name = 'cities' AND column_name='name';"
-    expected_output: "[{\"column_name\"=>\"name\"}]"
-    error_message: "It looks like you might be missing the name column."
+  - test_query: "select column_name from INFORMATION_SCHEMA.COLUMNS where table_name = 'cities' AND column_name='city_name';"
+    expected_output: "[{\"column_name\"=>\"city_name\"}]"
+    error_message: "Your table should include a column named city_name"
   - test_query: "select column_name from INFORMATION_SCHEMA.COLUMNS where table_name = 'cities' AND column_name='population';"
     expected_output: "[{\"column_name\"=>\"population\"}]"
-    error_message: "It looks like you might be missing the population column."
+    error_message: "Your table should include a column named population"
   - test_query: "select COUNT(column_name) from INFORMATION_SCHEMA.COLUMNS where table_name = 'cities';"
     expected_output: "[{\"count\"=>\"2\"}]"
-    error_message: "Looks like you might have the wrong number of columns.\nYou should just have 2"
+    error_message: "Your table should have exactly 2 columns"
 level_schemas: 
   - 
     schema_columns: 
       - 
-        column_name: name
+        column_name: city_name
         column_type: varchar(255)
       - 
         column_name: population

--- a/db/levels/lvl5.yml
+++ b/db/levels/lvl5.yml
@@ -2,7 +2,7 @@ correct_query: "INSERT INTO missiles VALUES ('Topol', 'USSR');"
 level: 
   stage_number: 5
   title: "Insertopol"
-  prompt: "Use <code>INSERT</code> to add a record with <code>name</code> 'Topol' and <code>nationality</code> 'USSR' to the <code>missiles</code> table."
+  prompt: "Use <code>INSERT</code> to add a record with <code>model_name</code> 'Topol' and <code>nationality</code> 'USSR' to the <code>missiles</code> table."
   database_path: "db/dumps/lvl5.sql"
   answer: ""
   level_type: "insert"
@@ -16,7 +16,7 @@ level_pages:
 level_tests:
   - test_query: "select count(*) from missiles where model_name = 'Topol' AND nationality='USSR';"
     expected_output: "[{\"count\"=>\"2\"}]"
-    error_message: "There should be two missiles named 'Topol' in the table."
+    error_message: "Your INSERT statement should have added another Topol missile to the table.\nThere should be exactly 2 Topol missiles in the missiles table"
   - test_query: "SELECT count(*) FROM missiles;"
     expected_output: "[{\"count\"=>\"9\"}]"
     error_message: "There should only be 9 rows in the table."

--- a/db/levels/lvl6.yml
+++ b/db/levels/lvl6.yml
@@ -1,10 +1,10 @@
-correct_query: "SELECT * FROM missiles WHERE id=3;"
+correct_query: "SELECT * FROM missiles WHERE missile_id=3;"
 level: 
   stage_number: 6
   title: "Will the real Topol<br> please stand up?"
-  prompt: "Select all the data for the first 'Topol' missile that appears in the <code>missiles</code> table by specifying the missile's <code>ID</code>"
+  prompt: "Select all the data for the first 'Topol' missile that appears in the <code>missiles</code> table by specifying the missile's <code>MISSILE_ID</code>"
   database_path: "db/dumps/lvl6.sql"
-  answer: "[{\"id\"=>\"3\", \"model_name\"=>\"Topol\", \"nationality\"=>\"Russia\"}]"
+  answer: "[{\"missile_id\"=>\"3\", \"model_name\"=>\"Topol\", \"nationality\"=>\"Russia\"}]"
   level_type: "read"
 level_pages:
   - page_number: 1
@@ -12,15 +12,15 @@ level_pages:
   - page_number: 2
     content: "<p>If you try <code>SELECT * FROM missiles WHERE model_name = 'Topol';</code> you will see that you actually return two missiles! Uh oh! How do get data on just the first?</p> <p>Enter <em>primary keys</em>.</p>"
   - page_number: 3
-    content: "<p>Primary keys are a way to uniquely identify a row of data in a table. In a typical database, each time a record is added the primary key column is automatically incremented, so that each row has a single unique identifier.</p>"
+    content: "<p>Primary keys are a way to uniquely identify a row of data in a table. In a typical database, each time a record is added the primary key column is automatically incremented, so that each row has a single unique number as its identifier.</p>"
   - page_number: 4  
-    content: "<p>Using the primary key, which is usually named something like 'id' or <em>'table_name_id'</em>, we can select just the single row we want. </p> <p> For example, <code>SELECT * from cats where id=1;</code> will return to us all of the info about the cat with ID=1.</p> <p>Complete this challenge by using ID to select all of the info about the first 'Topol' missile listed in the table. </p> <p> <em> Hint: First take a look at the table to the right, to determine the ID of the first 'Topol' missile. </em> </p>"
-default_text: "id    | model_name      | nationality     |\n‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾\n1     | Peacekeeper     | USA             |\n2     | Minuteman       | USA             |\n3     | Topol           | Russia          |\n4     | Yars            | Russia          |\n5     | Jericho III     | Israel          |\n6     | Agni-V          | India           |\n7     | East Wind 5     | China           |\n8     | East Wind 31    | China           |\n9     | Topol           | Russia          |\n"
+    content: "<p>Using the primary key, which is usually named something like 'id' or <em>'table_name_id'</em>, we can select just the single row we want. </p> <p> For example, <code>SELECT * from cats where cat_id=1;</code> will return to us all of the info about the cat with the <code>cat_id</code> of 1.</p> <p>Complete this challenge by using missile_id to select all of the info about the first 'Topol' missile listed in the table. </p> <p> <em> Hint: First take a look at the table to the right, to determine the missile_id of the first 'Topol' missile. </em> </p>"
+default_text: "missile_id | model_name      | nationality     | \n‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾\n1          | Peacekeeper     | USA             | \n2          | Minuteman       | USA             | \n3          | Topol           | Russia          | \n4          | Yars            | Russia          | \n5          | Jericho III     | Israel          | \n6          | Agni-V          | India           | \n7          | East Wind 5     | China           | \n8          | East Wind 31    | China           | \n9          | Topol           | Russia          |"
 level_schemas: 
   - 
     schema_columns: 
       - 
-        column_name: id
+        column_name: missile_id
         column_type: serial
       - 
         column_name: model_name
@@ -31,8 +31,8 @@ level_schemas:
     table_name: missiles
 level_tests:
   - test_query: "has_col?"
-    expected_output: "id"
-    error_message: "Your results should include the id column"
+    expected_output: "missile_id"
+    error_message: "Your results should include the missile_id column"
   - test_query: "has_col?"
     expected_output: "model_name"
     error_message: "Your results should include the model_name column"
@@ -46,5 +46,5 @@ level_tests:
     expected_output: 3
     error_message: "Your results should contain data from 3 columns"
   - test_query: "has_row?"
-    expected_output: "{\"id\"=> 3, \"model_name\" => \"Topol\", \"nationality\" => \"Russia\"}"
+    expected_output: "{\"missile_id\"=> 3, \"model_name\" => \"Topol\", \"nationality\" => \"Russia\"}"
     error_message: "Your results should contain the first record for the Topol missile"

--- a/db/levels/lvl7.yml
+++ b/db/levels/lvl7.yml
@@ -1,33 +1,33 @@
-correct_query: "CREATE TABLE missiles (id serial PRIMARY KEY, model_name VARCHAR(255), nationality VARCHAR(255));"
+correct_query: "CREATE TABLE missiles (missile_id serial PRIMARY KEY, model_name VARCHAR(255), nationality VARCHAR(255));"
 level: 
   stage_number: 7
   title: "Creating tables with primary keys."
-  prompt: "Recreate our <code>missiles</code> using the provided schema, including an <code>id</code> column."
+  prompt: "Recreate our <code>missiles</code> using the provided schema, including a <code>missile_id</code> column."
   database_path: "db/dumps/lvl7.sql"
   answer: ""
   level_type: "create"
 level_pages:
   - page_number: 1
-    content: "<p> In the last level, we saw the power of using <em>id</em>s to select specifically the data we need and to tell apart two otherwise identical records.</p><p> Intelligence Services has called upon you to recreate the <code>missiles</code> table from scratch, using <em>id</em>s this time. This way, we'll always be able to pass to Intelligence Services precise missile data.</p><p> We learned in Level 4 how to create a table using the <code>CREATE TABLE</code> command. Now, we're going to build on that by learning how to create tables with <em>id</em>s.</p>"
+    content: "<p> In the last level, we saw the power of using primary keyss to select the specific data we need and to tell apart two otherwise identical records.</p><p> Intelligence Services has called upon you to recreate the <code>missiles</code> table from scratch, using <em>missile_id</em>s this time. That way, we'll always be able to pass precise missile data to Intelligence Services.</p><p> We learned create a table using the <code>CREATE TABLE</code> command how to in Level 4. Now, we're going to build on that by learning how to create tables with primary keys.</p>"
   - page_number: 2
-    content: "<p> We've started you off with an empty database and no tables. Your job is to create a missiles table that has <em>id</em>'s in it. The convention for <em>ids</em> is that they are type:</p><p><code>INTEGER PRIMARY KEY AUTOINCREMENT</code></p><p><code> PRIMARY KEY </code> simply means that the column is UNIQUE and NOT NULL. UNIQUE is essential so that two rows never have the same ID, and NOT NULL is important so you never have a row without an <em>id</em>.</p><p><code>AUTOINCREMENT</code> means that this column's values will increment by 1 every time a new row is added.</p><p><code>SERIAL</code> is just shorthand in some database systems for <code>INTEGER</code><code> AUTOINCREMENT</code>, but note that this varies among different SQL implementations.</p>"
+    content: "<p> We've started you off with an empty database and no tables. Your job is to create a missiles table that has unique <em>missile_id</em>'s in it. In the database of MISSQL Command HQ, the convention for primary keys is to use the data type:</p><p><code>INTEGER serial PRIMARY KEY</code></p><p><code> PRIMARY KEY </code> simply means that the column is UNIQUE and NOT NULL. Being UNIQUE is essential so that two rows never have the same primary key, and NOT NULL is important so you never have a row without an <em>id</em>.</p><p><em>Tip: <code>serial</code> means that this column's values will increment by 1 every time a new row is added.</p><p>Different databases use different <em>functions</em> to automatically increment their primary keys. Many use a syntax like <code>INTEGER PRIMARY KEY AUTOINCREMENT</code></em></p>"
   - page_number: 3
-    content: "<p> Here's an example of how to create a table with <em>id</em>s. <pre><code>CREATE TABLE cats (\n  id SERIAL PRIMARY KEY,\n  name VARCHAR(64),\n  hair_color VARCHAR(64)\n);</code></pre> </p> <p> Now, can you recreate our <code>missile</code> table with <em>id</em>s? Take a look at the grey <code>missiles</code> tab to the right to inspect the schema you need to create.</p>"
+    content: "<p> Here's an example of how to create a table with unique <em>id</em>s. <pre><code>CREATE TABLE cats (\n  cat_id SERIAL PRIMARY KEY,\n  cat_name VARCHAR(64),\n  hair_color VARCHAR(64)\n);</code></pre> </p> <p> Now, can you recreate our <code>missile</code> table with <em>missile_id</em>s? Take a look at the grey <code>missiles</code> tab to the right to inspect the schema you'll need to create.</p>"
 level_tests:
-  - test_query: "select column_name from INFORMATION_SCHEMA.COLUMNS where table_name = 'missiles' AND column_name='id';"
-    expected_output: "[{\"column_name\"=>\"id\"}]"
-    error_message: "It looks like you are missing the id column."
+  - test_query: "select column_name from INFORMATION_SCHEMA.COLUMNS where table_name = 'missiles' AND column_name='missile_id';"
+    expected_output: "[{\"column_name\"=>\"missile_id\"}]"
+    error_message: "Your table should include a missile_id column"
   - test_query: "select column_name from INFORMATION_SCHEMA.COLUMNS where table_name = 'missiles' AND column_name='model_name';"
     expected_output: "[{\"column_name\"=>\"model_name\"}]"
-    error_message: "It looks like you are missing the model_name column."
+    error_message: "Your table should include a model_name column"
   - test_query: "select column_name from INFORMATION_SCHEMA.COLUMNS where table_name = 'missiles' AND column_name='nationality';"
     expected_output: "[{\"column_name\"=>\"nationality\"}]"
-    error_message: "It looks like you are missing the nationality column."
+    error_message: "Your table should include a nationality column"
 level_schemas: 
   - 
     schema_columns: 
       - 
-        column_name: id 
+        column_name: missile_id 
         column_type: serial PRIMARY KEY
       - 
         column_name: model_name

--- a/db/levels/lvl7.yml
+++ b/db/levels/lvl7.yml
@@ -12,17 +12,17 @@ level_pages:
   - page_number: 2
     content: "<p> We've started you off with an empty database and no tables. Your job is to create a missiles table that has unique <em>missile_id</em>'s in it. In the database of MISSQL Command HQ, the convention for primary keys is to use the data type:</p><p><code>INTEGER serial PRIMARY KEY</code></p><p><code> PRIMARY KEY </code> simply means that the column is UNIQUE and NOT NULL. Being UNIQUE is essential so that two rows never have the same primary key, and NOT NULL is important so you never have a row without an <em>id</em>.</p><p><em>Tip: <code>serial</code> means that this column's values will increment by 1 every time a new row is added.</p><p>Different databases use different <em>functions</em> to automatically increment their primary keys. Many use a syntax like <code>INTEGER PRIMARY KEY AUTOINCREMENT</code></em></p>"
   - page_number: 3
-    content: "<p> Here's an example of how to create a table with unique <em>id</em>s. <pre><code>CREATE TABLE cats (\n  cat_id SERIAL PRIMARY KEY,\n  cat_name VARCHAR(64),\n  hair_color VARCHAR(64)\n);</code></pre> </p> <p> Now, can you recreate our <code>missile</code> table with <em>missile_id</em>s? Take a look at the grey <code>missiles</code> tab to the right to inspect the schema you'll need to create.</p>"
+    content: "<p> Here's an example of how to create a table with unique <em>id</em>s. <pre><code>CREATE TABLE cats (\n  cat_id SERIAL PRIMARY KEY,\n  cat_name VARCHAR(64),\n  hair_color VARCHAR(64)\n);</code></pre> </p> <p> Now, can you recreate our <code>missile</code> table with <em>missile_id</em>s? Take a look at the grey <code>missiles</code> table to the right to inspect the schema you'll need to create.</p>"
 level_tests:
   - test_query: "select column_name from INFORMATION_SCHEMA.COLUMNS where table_name = 'missiles' AND column_name='missile_id';"
     expected_output: "[{\"column_name\"=>\"missile_id\"}]"
-    error_message: "Your table should include a missile_id column"
+    error_message: "Your table should include the missile_id column"
   - test_query: "select column_name from INFORMATION_SCHEMA.COLUMNS where table_name = 'missiles' AND column_name='model_name';"
     expected_output: "[{\"column_name\"=>\"model_name\"}]"
-    error_message: "Your table should include a model_name column"
+    error_message: "Your table should include the model_name column"
   - test_query: "select column_name from INFORMATION_SCHEMA.COLUMNS where table_name = 'missiles' AND column_name='nationality';"
     expected_output: "[{\"column_name\"=>\"nationality\"}]"
-    error_message: "Your table should include a nationality column"
+    error_message: "Your table should include the nationality column"
 level_schemas: 
   - 
     schema_columns: 

--- a/db/levels/lvl8.yml
+++ b/db/levels/lvl8.yml
@@ -2,7 +2,7 @@ correct_query: "SELECT missiles.target_city_id FROM missiles;"
 level: 
   stage_number: 8
   title: "Incoming Missiles!"
-  prompt: "Get a list of the <code>ids</code> of the targeted <code>cities</code>. Check the schema to see how!"
+  prompt: "Get a list of the <code>foreign keys</code> of cities in the missiles table"
   database_path: "db/dumps/lvl8.sql"
   answer: "[{\"target_city_id\"=>\"7\"}, {\"target_city_id\"=>\"5\"}, {\"target_city_id\"=>\"1\"}, {\"target_city_id\"=>\"4\"}, {\"target_city_id\"=>\"5\"}, {\"target_city_id\"=>\"7\"}, {\"target_city_id\"=>\"3\"}, {\"target_city_id\"=>\"6\"}]"
   level_type: "read"
@@ -15,7 +15,7 @@ level_schemas:
     table_name: missiles
     schema_columns: 
       - 
-        column_name: id
+        column_name: missile_id
         column_type: serial
       - 
         column_name: model_name

--- a/db/levels/lvl9.yml
+++ b/db/levels/lvl9.yml
@@ -1,25 +1,25 @@
-correct_query: "SELECT * FROM cities JOIN missiles on missiles.target_city_id = cities.id;"
+correct_query: "SELECT * FROM cities JOIN missiles on missiles.target_city_id = cities.city_id;"
 level: 
   stage_number: 9
   title: "JOIN Up!"
-  prompt: "Select all the data on <code>cities</code> and <code>missiles</code> targeting them using a JOIN."
+  prompt: "Select all the data on <code>cities</code> and the <code>missiles</code> targeting them using a JOIN."
   database_path: "db/dumps/lvl9.sql"
-  answer: "[{\"id\"=>\"3\", \"name\"=>\"New York\", \"population\"=>\"8337000\", \"model_name\"=>\"Topol\", \"nationality\"=>\"Russia\", \"target_city_id\"=>\"1\"}, {\"id\"=>\"7\", \"name\"=>\"San Francisco\", \"population\"=>\"825000\", \"model_name\"=>\"Dongfeng-5\", \"nationality\"=>\"China\", \"target_city_id\"=>\"3\"}, {\"id\"=>\"4\", \"name\"=>\"London\", \"population\"=>\"8308000\", \"model_name\"=>\"Yars\", \"nationality\"=>\"Russia\", \"target_city_id\"=>\"4\"}, {\"id\"=>\"5\", \"name\"=>\"Moscow\", \"population\"=>\"11500000\", \"model_name\"=>\"Jericho III\", \"nationality\"=>\"Israel\", \"target_city_id\"=>\"5\"}, {\"id\"=>\"2\", \"name\"=>\"Moscow\", \"population\"=>\"11500000\", \"model_name\"=>\"Minuteman\", \"nationality\"=>\"USA\", \"target_city_id\"=>\"5\"}, {\"id\"=>\"8\", \"name\"=>\"Tokyo\", \"population\"=>\"13230000\", \"model_name\"=>\"Dongfeng-31\", \"nationality\"=>\"China\", \"target_city_id\"=>\"6\"}, {\"id\"=>\"6\", \"name\"=>\"Shanghai\", \"population\"=>\"24000000\", \"model_name\"=>\"Agni-V\", \"nationality\"=>\"India\", \"target_city_id\"=>\"7\"}, {\"id\"=>\"1\", \"name\"=>\"Shanghai\", \"population\"=>\"24000000\", \"model_name\"=>\"Peacekeeper\", \"nationality\"=>\"USA\", \"target_city_id\"=>\"7\"}]"
+  answer: "[{\"city_id\"=>\"1\", \"city_name\"=>\"New York\", \"population\"=>\"8337000\", \"missile_id\"=>\"3\", \"model_name\"=>\"Topol\", \"nationality\"=>\"Russia\", \"target_city_id\"=>\"1\"}, {\"city_id\"=>\"3\", \"city_name\"=>\"San Francisco\", \"population\"=>\"825000\", \"missile_id\"=>\"7\", \"model_name\"=>\"Dongfeng-5\", \"nationality\"=>\"China\", \"target_city_id\"=>\"3\"}, {\"city_id\"=>\"4\", \"city_name\"=>\"London\", \"population\"=>\"8308000\", \"missile_id\"=>\"4\", \"model_name\"=>\"Yars\", \"nationality\"=>\"Russia\", \"target_city_id\"=>\"4\"}, {\"city_id\"=>\"5\", \"city_name\"=>\"Moscow\", \"population\"=>\"11500000\", \"missile_id\"=>\"5\", \"model_name\"=>\"Jericho III\", \"nationality\"=>\"Israel\", \"target_city_id\"=>\"5\"}, {\"city_id\"=>\"5\", \"city_name\"=>\"Moscow\", \"population\"=>\"11500000\", \"missile_id\"=>\"2\", \"model_name\"=>\"Minuteman\", \"nationality\"=>\"USA\", \"target_city_id\"=>\"5\"}, {\"city_id\"=>\"6\", \"city_name\"=>\"Tokyo\", \"population\"=>\"13230000\", \"missile_id\"=>\"8\", \"model_name\"=>\"Dongfeng-31\", \"nationality\"=>\"China\", \"target_city_id\"=>\"6\"}, {\"city_id\"=>\"7\", \"city_name\"=>\"Shanghai\", \"population\"=>\"24000000\", \"missile_id\"=>\"6\", \"model_name\"=>\"Agni-V\", \"nationality\"=>\"India\", \"target_city_id\"=>\"7\"}, {\"city_id\"=>\"7\", \"city_name\"=>\"Shanghai\", \"population\"=>\"24000000\", \"missile_id\"=>\"1\", \"model_name\"=>\"Peacekeeper\", \"nationality\"=>\"USA\", \"target_city_id\"=>\"7\"}]" 
   level_type: "read"
 level_pages:
   - page_number: 1
-    content: "<p>Now that you've seen how to get the foreign keys from a table, it's time to use them to find data in a different table using a <code>JOIN</code> statement. A <code>JOIN</code> is essentially a <code>SELECT</code> statement that operates on two or more tables.</p><p>This stage has two tables, <code>cities</code> and <code>missiles</code>. Just like last time, the missiles table holds foreign keys in its <code>target_city_id</code> column.</p><p>These keys can be used to find all of the cities currently being targeted by ICBMs by matching them to the cities' id. There are several types of <code>JOIN</code> in SQL, but the first one we'll be dealing with is an <code>INNER JOIN</code>, which takes two tables and returns results from all rows from both tables that match the joining condition.</p><p>An inner join statement uses the following syntax:</p><p><pre><code>SELECT * FROM cats\n JOIN owners\n ON cats.owner_id = owners.id;</code></pre></p>"
+    content: "<p>Now that you've seen how to get the foreign keys from a table, it's time to use them to find data in a different table using a <code>JOIN</code> statement. A <code>JOIN</code> is essentially a <code>SELECT</code> statement that operates on two or more tables.</p><p>This stage has two tables, <code>cities</code> and <code>missiles</code>. Just like last time, the missiles table holds foreign keys in its <code>target_city_id</code> column.</p><p>These keys can be used to find all of the cities currently being targeted by ICBMs by matching them to the cities' primary key, city_id. There are several types of <code>JOIN</code> in SQL, but the first one we'll be dealing with is an <code>INNER JOIN</code>, which takes two tables and returns results from all rows from both tables that match the joining condition.</p><p>An inner join statement uses the following syntax:</p><p><pre><code>SELECT * FROM cats\n JOIN owners\n ON cats.owner_id = owners.id;</code></pre></p>"
   - page_number: 2
-    content: "<p>Let's break that down. The first part of a <code>JOIN</code> is just a plain old SELECT, telling the database what columns you want to retrieve from the rows matched by the query. You can select any columns from any of the tables in the join, so here we're selecting all rows from both tables. The second part of the statement is the <code>JOIN</code> keyword itself, which is immediately followed by the name of the table you want to <code>JOIN</code>. The <code>ON</code> keyword is followed by a conditional statement (which looks a lot like a <code>WHERE</code> statement) that is used to match rows from the different table. When a row from one table is compared with a row from another and the <code>ON</code> condition is true, the two rows will be joined into one row in the results. Here we're matching cats to owners where the cat's <code>owner_id</code> column is equal to an owner's primary key column, <code>id</code>. They primary key of a table is typically named 'id', or 'tablename_id'. All together, this statment will collate the rows of <code>cats</code> that have an <code>owner_id</code> with any rows of <code>owners</code> that have a matching id column, and then return all columns from both rows as a new table.</p><p>See if you can write a JOIN to get all the information from the cities table, joined to the missile table using the missile table's <code>target_city_id</code> column. Check out the schema about the command input for guidance."
+    content: "<p>Let's break that down. The first part of a <code>JOIN</code> is just a plain old SELECT, telling the database what columns you want to retrieve from the rows matched by the query. You can select any columns from any of the tables in the join, so here we're selecting all rows from both tables. The second part of the statement is the <code>JOIN</code> keyword itself, which is immediately followed by the name of the table you want to <code>JOIN</code>. The <code>ON</code> keyword is followed by a conditional statement (which looks a lot like a <code>WHERE</code> statement) that is used to match rows from the different table. When a row from one table is compared with a row from another and the <code>ON</code> condition is true, the two rows will be joined into one row in the results. Here we're matching cats to owners where the cat's <code>owner_id</code> column is equal to an owner's primary key column, <code>id</code>. They primary key of a table is typically named 'id', or <em>'tablename_id'</em>. All together, this statment will collate the rows of <code>cats</code> that have an <code>owner_id</code> with any rows of <code>owners</code> that have a matching id column, and then return all columns from both rows as a new table.</p><p>See if you can write a JOIN to get all the information from the cities table, joined to the missile table using the missile table's <code>target_city_id</code> column. Check out the schema about the command input for guidance."
 level_schemas: 
   - 
     table_name: cities
     schema_columns: 
       - 
-        column_name: id
+        column_name: city_id
         column_type: serial
       - 
-        column_name: name
+        column_name: city_name
         column_type: varchar(255)
       - 
         column_name: population
@@ -28,7 +28,7 @@ level_schemas:
     table_name: missiles
     schema_columns: 
       - 
-        column_name: id
+        column_name: missile_id
         column_type: serial
       - 
         column_name: model_name
@@ -41,10 +41,10 @@ level_schemas:
         column_type: integer
 level_tests:
   - test_query: "has_col?"
-    expected_output: "id"
+    expected_output: "city_id"
     error_message: "Your results should include the id column"
   - test_query: "has_col?"
-    expected_output: "name"
+    expected_output: "city_name"
     error_message: "Your results should include the name column from the cities table"
   - test_query: "has_col?"
     expected_output: "population"
@@ -59,7 +59,7 @@ level_tests:
     expected_output: "target_city_id"
     error_message: "Your results should include the target_city_id column from the missiles table"
   - test_query: "has_col_count?"
-    expected_output: 6
+    expected_output: 7
     error_message: "Your results should have 6 different columns"
   - test_query: "has_row_count?"
     expected_output: 8

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,16 +3,3 @@ Dir.glob('db/levels/*.yml') do |yml_file|
   Level.load_from_yaml(yml_file)
 end
 
-#Create test users
-test_user = User.create(
-  :user_name => "Test User",
-  :email => "test@test.com",
-  :password => "test",
-  :password_confirmation => "test"
-)
-test_user_2 = User.create(
-  :user_name => "Test User 2",
-  :email => "test2@test.com",
-  :password => "test",
-  :password_confirmation => "test"
-)

--- a/spec/feature_helper.rb
+++ b/spec/feature_helper.rb
@@ -1,3 +1,5 @@
 require 'spec_helper'
 require 'capybara/rspec'
 require 'capybara/rails'
+require 'capybara/poltergeist'
+Capybara.javascript_driver = :poltergeist

--- a/spec/features/level_play_spec.rb
+++ b/spec/features/level_play_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../feature_helper'
 
-describe 'Level: ', :js => true do
+describe 'Level play: ', :js => true do
 
     before :each do     
       @user = FactoryGirl.create(:user)
@@ -18,6 +18,7 @@ describe 'Level: ', :js => true do
       # Need to change the harcoded number below to Level.all.count. Some scope issues here.
           10.times { | stage_number |
               it "Level #{stage_number+1} should have a Title on its page" do
+                
                 @level = Level.find_by(:stage_number => stage_number+1)
                 visit "/levels/#{@level.stage_number}"
                 expect(page).to have_content(ActionView::Base.full_sanitizer.sanitize(@level.title))

--- a/spec/features/session_spec.rb
+++ b/spec/features/session_spec.rb
@@ -84,6 +84,16 @@ describe "Session" do
       expect(page).to have_content("User name has already been taken")
     end
 
+    it "should redirect you to the homepage if you're logged in" do
+      @user.save
+      visit '/login'
+      fill_in 'email', :with => @user.email
+      fill_in 'Password', :with => @user.password
+      click_button 'Login'
+      visit '/users/new'
+      expect(current_path).to eq("/")
+    end
+
     it "should tell you if your password doesn't match the confirmation" do
       visit '/users/new'
       fill_in 'Username', :with => @user.user_name

--- a/spec/fixtures/test.sql
+++ b/spec/fixtures/test.sql
@@ -1,0 +1,1 @@
+CREATE TABLE cities_test (city_id serial PRIMARY KEY, city_name VARCHAR(255));

--- a/spec/fixtures/test.yml
+++ b/spec/fixtures/test.yml
@@ -1,0 +1,28 @@
+correct_query: "SELECT city_name from cities;"
+level: 
+  answer: "[{\"test\"=>\"test\"}]"
+  database_path: test.sql
+  level_type: read
+  prompt: "Test prompt"
+  stage_number: 99
+  title: "Test"
+level_pages: 
+  - page_number: 1
+    content: "<p>Hello Commander, and welcome to the <code>MISSQL COMMAND</code> console! Your job is to defend the world's cities from a missile attack (and learn some <code>SQL</code> along the way!).</p><p><code>SQL</code>, or <a href='http://en.wikipedia.org/wiki/Sql' target='_blank'>Structured Query Language</a>, is a standarized programming language used to accesss and interact with <a href='http://en.wikipedia.org/wiki/Relational_database' target='_blank'>relational databases</a>.</p><p>So what is a relational database? A relational database is a method of storing data in <em>tables</em>, which have rows and columns. </p>"
+level_schemas: 
+  - 
+    schema_columns: 
+      - 
+        column_name: city_name
+        column_type: varchar(255)
+      - 
+        column_name: population
+        column_type: integer
+    table_name: cities
+level_tests:
+  - test_query: "has_col?"
+    expected_output: "city_name"
+    error_message: "Your results should have the city_name column"
+  - test_query: "has_col_count?"
+    expected_output: "1"
+    error_message: "Your results should include exactly 1 column"

--- a/spec/fixtures/test_update.yml
+++ b/spec/fixtures/test_update.yml
@@ -1,0 +1,30 @@
+correct_query: "SELECT city_name from cities;"
+level: 
+  answer: "Test answer"
+  database_path: test.sql
+  level_type: read
+  prompt: "Test prompt"
+  stage_number: 99
+  title: "Test 2"
+level_pages: 
+  - page_number: 1
+    content: "<p>Hello Commander, and welcome to the <code>MISSQL COMMAND</code> console! Your job is to defend the world's cities from a missile attack (and learn some <code>SQL</code> along the way!).</p><p><code>SQL</code>, or <a href='http://en.wikipedia.org/wiki/Sql' target='_blank'>Structured Query Language</a>, is a standarized programming language used to accesss and interact with <a href='http://en.wikipedia.org/wiki/Relational_database' target='_blank'>relational databases</a>.</p><p>So what is a relational database? A relational database is a method of storing data in <em>tables</em>, which have rows and columns. </p>"
+  - page_number: 2
+    content: "<p>Hello Commander, and welcome to the <code>MISSQL COMMAND</code> console! Your job is to defend the world's cities from a missile attack (and learn some <code>SQL</code> along the way!).</p><p><code>SQL</code>, or <a href='http://en.wikipedia.org/wiki/Sql' target='_blank'>Structured Query Language</a>, is a standarized programming language used to accesss and interact with <a href='http://en.wikipedia.org/wiki/Relational_database' target='_blank'>relational databases</a>.</p><p>So what is a relational database? A relational database is a method of storing data in <em>tables</em>, which have rows and columns. </p>"
+level_schemas: 
+  - 
+    schema_columns: 
+      - 
+        column_name: city_name
+        column_type: varchar(255)
+      - 
+        column_name: population
+        column_type: integer
+      - 
+        column_name: name
+        column_type: integer
+    table_name: cities
+level_tests:
+  - test_query: "has_col?"
+    expected_output: "city_name"
+    error_message: "Your results should have the city_name column"

--- a/spec/models/level_spec.rb
+++ b/spec/models/level_spec.rb
@@ -1,0 +1,111 @@
+require 'spec_helper'
+
+describe Level do
+
+	describe "::load_from_yaml" do
+		before(:each) do
+			Level.load_from_yaml(File.expand_path("../../fixtures/test.yml", __FILE__))
+			@level = Level.find_by(:stage_number => 99)
+		end
+		it "creates a new level from a YAML file" do
+			expect(@level.title).to eq("Test")
+		end
+		it "creates a new level's pages from a YAML file" do
+			expect(@level.level_pages).to_not be_empty
+		end
+		it "creates a new level's tests from a YAML file" do
+			expect(@level.level_tests).to_not be_empty
+		end
+		it "creates a new level's schemata from a YAML file" do
+			expect(@level.level_schemas).to_not be_empty
+		end
+
+	end
+
+	describe "::update_from_yaml" do
+		before(:each) do
+			Level.load_from_yaml(File.expand_path("../../fixtures/test.yml", __FILE__))
+			@level = Level.find_by(:stage_number => 99)
+			Level.update_from_yaml(File.expand_path("../../fixtures/test_update.yml", __FILE__))
+			@level.reload
+		end
+		it "updates an existing level from a YAML file" do
+			expect(@level.title).to eq("Test 2")
+		end
+		it "creates a new level's pages from a YAML file" do
+			expect(@level.level_pages.count).to eq(2)
+		end
+		it "creates a new level's tests from a YAML file" do
+			expect(@level.level_tests.count).to eq(1)
+		end
+		it "creates a new level's schemata from a YAML file" do
+			expect(@level.level_schemas.count).to eq(1)
+			expect(@level.level_schemas.first.schema_columns.count).to eq(3)
+		end
+
+	end
+
+	describe "instance methods" do
+
+		before(:each) do
+			Level.load_from_yaml(File.expand_path("../../fixtures/test.yml", __FILE__))
+			@level = Level.find_by(:stage_number => 99)
+		end
+
+		describe "#correct_answer?" do
+			let(:result){
+				[{"test" => "test"}]
+			}
+			it "takes a pg result object and compares it to the correct answer" do
+				expect(@level.correct_answer?(result)).to eq(true)
+			end
+		end
+
+		describe "#ordered_pages" do
+			it "returns the level pages in order" do
+				expect(@level.ordered_pages).to_not be_empty
+			end
+		end
+
+		describe "#prev_level" do
+			it "gets the previous level if there is one" do
+				expect(Level.find_by(:stage_number=>2).prev_level).to be_an_instance_of(Level)
+			end
+			it "returns an empty association if there is no previous level" do
+				expect(@level.prev_level).to be_nil
+			end
+		end
+
+		describe "#next_level" do
+			it "gets the previous level if there is one" do
+				expect(Level.find_by(:stage_number=>2).next_level).to  be_an_instance_of(Level)
+			end
+			it "returns an empty association if there is no previous level" do
+				expect(@level.next_level).to be_nil
+			end
+		end
+	end
+
+	describe "#load_dump" do	
+	
+		before(:each) do
+			@level = Level.new().tap{ |l|
+				l.database_path = File.expand_path("../../fixtures/test.sql", __FILE__)
+				l.stage_number = 99
+				l.title = "Test Level"
+				l.prompt = "Test prompt"
+			}
+		end
+	
+		it "loads the Level's tables from file" do
+			@level.save
+			expect(@level.dump).to eq(File.read(File.expand_path("../../fixtures/test.sql", __FILE__)))
+		end
+
+		it "is nil if the level's database_path is empty" do
+			@level.database_path = ""
+			expect(@level.dump).to eq(nil)
+		end
+	end
+	
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,59 +13,35 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 require_relative 'support/wait_for_ajax.rb'
 
-# Checks for pending migrations before tests are run.
-# If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
-  # ## Mock Framework
-  #
-  # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:
-  #
-  # config.mock_with :mocha
-  # config.mock_with :flexmock
-  # config.mock_with :rr
 
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.include FactoryGirl::Syntax::Methods
   config.include Capybara::DSL
   config.include WaitForAjax, type: :feature
 
   # Database cleaner
   config.before(:suite) do
-    DatabaseCleaner.clean_with(:truncation)
-    `RAILS_ENV=test rake missql:reset`    
-    @level_count = Level.count
+    `RAILS_ENV=test rake missql:clean_test_databases`
+    `RAILS_ENV=test rake missql:reset`
   end
 
   config.after(:suite) do
-    DatabaseCleaner.clean_with(:truncation)
+    DatabaseCleaner.clean
     ActiveRecord::Base.remove_connection    
-    `RAILS_ENV=test rake missql:clean`
+    `RAILS_ENV=test rake missql:clean_test_databases`
   end
   
-  config.before(:each) do
-    `RAILS_ENV=test rake missql:reload_all`
-  end
+
   config.after(:each) do
-    # User.destroy_all
     DatabaseCleaner.clean_with(:truncation)
+    `RAILS_ENV=test rake missql:reload_all`
   end  
 
-  # If you're not using ActiveRecord, or you'd prefer not to run each of your
-  # examples within a transaction, remove the following line or assign false
-  # instead of true.
   config.use_transactional_fixtures = false
 
-  # If true, the base class of anonymous controllers will be inferred
-  # automatically. This will be the default behavior in future versions of
-  # rspec-rails.
   config.infer_base_class_for_anonymous_controllers = false
 
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
   config.order = "default"
 end


### PR DESCRIPTION
Refactors all levels to use disambiguated column names. This is especially useful in the levels with foreign/primary key lessons and JOINs. Passes current test suite. Needs review from another pair of :eyes: 
